### PR TITLE
Format codebase with Ormolu

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,9 +16,20 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  check-formatting:
+    name: Check formatting
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Check formatting of Haskell source code with Ormolu
+        uses: haskell-actions/run-ormolu@v16
+
   build:
     name: Build and test with GHC ${{ matrix.ghc-version }}
     runs-on: ubuntu-latest
+    needs: check-formatting
     strategy:
       fail-fast: false
       matrix:

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -8,42 +8,40 @@ import Control.Monad (unless)
 import Control.Monad.Trans.Class (lift)
 import Data.List (isPrefixOf, stripPrefix)
 import Data.String.Interpolate (i)
+import Data.Text qualified as T
 import Data.Version (showVersion)
 import Effectful (Eff, IOE, MonadIO, liftIO, runEff, (:>))
 import Effectful.State.Static.Local (State, evalState, get, modify, put)
-import Options.Applicative (
-  execParser,
-  fullDesc,
-  header,
-  help,
-  helper,
-  info,
-  long,
-  metavar,
-  short,
-  strArgument,
-  switch,
- )
-import System.Console.Haskeline (
-  InputT,
-  defaultSettings,
-  getInputLine,
-  runInputT,
- )
+import Options.Applicative
+  ( execParser,
+    fullDesc,
+    header,
+    help,
+    helper,
+    info,
+    long,
+    metavar,
+    short,
+    strArgument,
+    switch,
+  )
+import Paths_sly qualified as P (version)
+import Sly.Eval
+  ( Bindings,
+    Program (Program, bindings, terms),
+    fileToProgram,
+    runProgram,
+    stringToProgram,
+  )
+import Sly.Syntax (Name (..), astShow)
+import System.Console.Haskeline
+  ( InputT,
+    defaultSettings,
+    getInputLine,
+    runInputT,
+  )
 import System.Random (initStdGen, uniformR)
 import Text.Megaparsec (errorBundlePretty)
-
-import Data.Text qualified as T
-
-import Paths_sly qualified as P (version)
-import Sly.Eval (
-  Bindings,
-  Program (Program, bindings, terms),
-  fileToProgram,
-  runProgram,
-  stringToProgram,
- )
-import Sly.Syntax (Name (..), astShow)
 
 data Options = Options {file :: Maybe String, version :: Bool}
 
@@ -51,42 +49,45 @@ versionString :: String
 versionString = "sly v" <> showVersion P.version
 
 -- NOTE: This should not conflict with valid program syntax.
+
 -- | The prefix used for REPL commands.
 commandPrefix :: String
 commandPrefix = ":"
 
-outputStr :: MonadIO m => String -> m ()
+outputStr :: (MonadIO m) => String -> m ()
 outputStr = liftIO . putStr
 
-outputStrLn :: MonadIO m => String -> m ()
+outputStrLn :: (MonadIO m) => String -> m ()
 outputStrLn = liftIO . putStrLn
 
 main :: IO ()
 main = (runEff . run) =<< execParser opts
- where
-  opts = info
-    (parser <**> helper)
-    (fullDesc <> header "sly - An interpreter for the pure untyped λ-calculus.")
-  parser = do
-    file <- optional $ strArgument (metavar "FILE")
-    version <- switch
-      (long "version" <> short 'V' <> help "Print version and exit")
-    pure Options{..}
+  where
+    opts =
+      info
+        (parser <**> helper)
+        (fullDesc <> header "sly - An interpreter for the pure untyped λ-calculus.")
+    parser = do
+      file <- optional $ strArgument (metavar "FILE")
+      version <-
+        switch
+          (long "version" <> short 'V' <> help "Print version and exit")
+      pure Options {..}
 
-run :: IOE :> es => Options -> Eff es ()
+run :: (IOE :> es) => Options -> Eff es ()
 run opts = do
   if opts.version
     then outputStrLn versionString
     else maybe repl runFile opts.file
 
-runFile :: IOE :> es => String -> Eff es ()
+runFile :: (IOE :> es) => String -> Eff es ()
 runFile path = do
   result <- liftIO $ fileToProgram path
   case result of
     Left bundle -> outputStr (errorBundlePretty bundle)
     Right program -> mapM_ (liftIO . print) (runProgram program)
 
-repl :: IOE :> es => Eff es ()
+repl :: (IOE :> es) => Eff es ()
 repl = do
   let adjectives = ["cunning", "crafty", "guileful", "shrewd"] :: [String]
 
@@ -97,64 +98,67 @@ repl = do
   outputStrLn "Type :quit or press C-d to exit."
 
   evalState mempty $ runInputT defaultSettings loop
- where
-  loop :: (State Bindings :> es, IOE :> es) => InputT (Eff es) ()
-  loop = do
-    getInputLine "~> " >>= \case
-      Nothing -> return ()
-      Just input
-        | commandPrefix `isPrefixOf` input -> do
-          shouldQuit <- lift $ runCommand (tail input)
-          unless shouldQuit loop
-        | otherwise -> do
-          case stringToProgram (T.pack input) of
-            Left bundle -> outputStr (errorBundlePretty bundle)
-            Right program -> do
-              lift $ modify (<> program.bindings)
-              bindings <- lift get
-              mapM_ (liftIO . print) $
-                runProgram Program{bindings, terms = program.terms}
-          loop
+  where
+    loop :: (State Bindings :> es, IOE :> es) => InputT (Eff es) ()
+    loop = do
+      getInputLine "~> " >>= \case
+        Nothing -> return ()
+        Just input
+          | commandPrefix `isPrefixOf` input -> do
+              shouldQuit <- lift $ runCommand (tail input)
+              unless shouldQuit loop
+          | otherwise -> do
+              case stringToProgram (T.pack input) of
+                Left bundle -> outputStr (errorBundlePretty bundle)
+                Right program -> do
+                  lift $ modify (<> program.bindings)
+                  bindings <- lift get
+                  mapM_ (liftIO . print) $
+                    runProgram Program {bindings, terms = program.terms}
+              loop
 
 -- TODO: Refactor this to be less ad-hoc.
+
 -- | Run an interpreter command.
 runCommand :: (State Bindings :> es, IOE :> es) => String -> Eff es Bool
 runCommand input
   | command `elem` ["q", "quit"] = return True
-  | command == "parse", Just term <- stripPrefix "parse " input = do
-    case stringToProgram (T.pack term) of
-      Left bundle -> outputStr (errorBundlePretty bundle)
-      Right program -> mapM_ (outputStrLn . astShow) program.terms
-    return False
-  | command == "load", Just filepath <- stripPrefix "load " input = do
-    result <- liftIO $ fileToProgram filepath
-    case result of
-      Left bundle -> outputStr (errorBundlePretty bundle)
-      Right program -> do
-        mapM_ (liftIO . print) (runProgram program)
-        modify (<> program.bindings)
-    return False
+  | command == "parse",
+    Just term <- stripPrefix "parse " input = do
+      case stringToProgram (T.pack term) of
+        Left bundle -> outputStr (errorBundlePretty bundle)
+        Right program -> mapM_ (outputStrLn . astShow) program.terms
+      return False
+  | command == "load",
+    Just filepath <- stripPrefix "load " input = do
+      result <- liftIO $ fileToProgram filepath
+      case result of
+        Left bundle -> outputStr (errorBundlePretty bundle)
+        Right program -> do
+          mapM_ (liftIO . print) (runProgram program)
+          modify (<> program.bindings)
+      return False
   | command `elem` ["b", "bindings"] = do
-    let format (Name n, t) = T.unpack n <> " := " <> show t
-    bindings <- get
-    mapM_ (outputStrLn . format) bindings
-    return False
+      let format (Name n, t) = T.unpack n <> " := " <> show t
+      bindings <- get
+      mapM_ (outputStrLn . format) bindings
+      return False
   | command == "clear" = put mempty >> return False
   -- TODO: Generate this help string more robustly.
   | command `elem` ["?", "h", "help"] = do
-    outputStrLn $
-      "Commands available from the prompt:\n"
-        <> "  :parse <term>     show the parse tree for <term> in bracketed form\n"
-        <> "  :load, :l <path>  load a sly program, evaluating its terms and adding\n"
-        <> "                    its bindings to the environment\n"
-        <> "  :bindings, :b     show all bindings in the environment\n"
-        <> "  :clear            clear the environment\n"
-        <> "  :help, :?         view this list of commands\n"
-        <> "  :quit, :q         exit sly"
-    return False
+      outputStrLn $
+        "Commands available from the prompt:\n"
+          <> "  :parse <term>     show the parse tree for <term> in bracketed form\n"
+          <> "  :load, :l <path>  load a sly program, evaluating its terms and adding\n"
+          <> "                    its bindings to the environment\n"
+          <> "  :bindings, :b     show all bindings in the environment\n"
+          <> "  :clear            clear the environment\n"
+          <> "  :help, :?         view this list of commands\n"
+          <> "  :quit, :q         exit sly"
+      return False
   | otherwise = do
-    outputStrLn $ "Unrecognised REPL command: " <> command
-    outputStrLn "Use :? for help."
-    return False
- where
-  command = head $ words input
+      outputStrLn $ "Unrecognised REPL command: " <> command
+      outputStrLn "Use :? for help."
+      return False
+  where
+    command = head $ words input

--- a/src/Sly/Syntax.hs
+++ b/src/Sly/Syntax.hs
@@ -1,28 +1,27 @@
 -- SPDX-FileCopyrightText: 2022 Severen Redwood <sev@severen.dev>
 -- SPDX-License-Identifier: GPL-3.0-or-later
 
-module Sly.Syntax (
-  Name (..),
-  Statement (..),
-  Term (..),
-  astShow,
-  toChurchNat,
-  fromChurchNat,
-  toChurchBool,
-  fromChurchBool,
-) where
+module Sly.Syntax
+  ( Name (..),
+    Statement (..),
+    Term (..),
+    astShow,
+    toChurchNat,
+    fromChurchNat,
+    toChurchBool,
+    fromChurchBool,
+  )
+where
 
 import Data.String (IsString)
 import Data.String.Interpolate (i)
 import Data.Text (Text)
-
 import Data.Text qualified as T
 
-{- | A name in a program.
-
- A name is an identifier that is either used as a variable or an identifier to which an
- arbitrary term is bound.
--}
+-- | A name in a program.
+--
+-- A name is an identifier that is either used as a variable or an identifier to which an
+-- arbitrary term is bound.
 newtype Name = Name Text deriving (Eq, Ord, Show, IsString)
 
 -- | A program statement.
@@ -49,28 +48,28 @@ data Term
 
 instance Show Term where
   show = T.unpack . go
-   where
-    go :: Term -> Text
-    go (Var (Name n)) = n
-    go (Abs (Name n) body) = "λ" <> n <> slurp body
-    go (App l@(Abs _ _) r@(Abs _ _)) = [i|(#{go l}) (#{go r})|]
-    go (App l@(Abs _ _) r) = [i|(#{go l}) #{go r}|]
-    go (App l r@(Abs _ _)) = [i|#{go l} (#{go r})|]
-    go (App l r@(App _ _)) = [i|#{go l} (#{go r})|]
-    go (App l r) = [i|#{go l} #{go r}|]
+    where
+      go :: Term -> Text
+      go (Var (Name n)) = n
+      go (Abs (Name n) body) = "λ" <> n <> slurp body
+      go (App l@(Abs _ _) r@(Abs _ _)) = [i|(#{go l}) (#{go r})|]
+      go (App l@(Abs _ _) r) = [i|(#{go l}) #{go r}|]
+      go (App l r@(Abs _ _)) = [i|#{go l} (#{go r})|]
+      go (App l r@(App _ _)) = [i|#{go l} (#{go r})|]
+      go (App l r) = [i|#{go l} #{go r}|]
 
-    -- Slurp up λ-abstractions!
-    slurp :: Term -> Text
-    slurp (Abs (Name n) body) = " " <> n <> slurp body
-    slurp body = " -> " <> go body
+      -- Slurp up λ-abstractions!
+      slurp :: Term -> Text
+      slurp (Abs (Name n) body) = " " <> n <> slurp body
+      slurp body = " -> " <> go body
 
 -- | Like regular show, but displays the term fully bracketed.
 astShow :: Term -> String
 astShow = T.unpack . go
- where
-  go (Var (Name n)) = n
-  go (Abs (Name n) t) = [i|(λ#{n} -> #{go t})|]
-  go (App l r) = [i|(#{go l} #{go r})|]
+  where
+    go (Var (Name n)) = n
+    go (Abs (Name n) t) = [i|(λ#{n} -> #{go t})|]
+    go (App l r) = [i|(#{go l} #{go r})|]
 
 -- | Convert a nonnegative integer into a Church numeral term.
 toChurchNat :: Int -> Term
@@ -83,12 +82,12 @@ toChurchNat n =
 --   numeral.
 fromChurchNat :: Term -> Maybe Int
 fromChurchNat (Abs f (Abs x body)) = go 0 body
- where
-  go :: Int -> Term -> Maybe Int
-  go n = \case
-    Var y | y == x -> Just n
-    App (Var g) t | g == f -> go (n + 1) t
-    _ -> Nothing
+  where
+    go :: Int -> Term -> Maybe Int
+    go n = \case
+      Var y | y == x -> Just n
+      App (Var g) t | g == f -> go (n + 1) t
+      _ -> Nothing
 fromChurchNat _ = Nothing
 
 -- | Convert a Boolean into a Church Boolean term.

--- a/tests/PropertyTests.hs
+++ b/tests/PropertyTests.hs
@@ -6,18 +6,17 @@ module PropertyTests (propertyTests) where
 import Hedgehog
 import Hedgehog.Gen qualified as Gen
 import Hedgehog.Range qualified as Range
+import Sly.Syntax (fromChurchBool, fromChurchNat, toChurchBool, toChurchNat)
 import Test.Tasty
 import Test.Tasty.Hedgehog
-
-import Sly.Syntax (fromChurchNat, toChurchNat, fromChurchBool, toChurchBool)
 
 propertyTests :: TestTree
 propertyTests =
   fromGroup $
     Group
       "Property Tests"
-      [ ("forall n. (fromChurchNat . toChurchNat) n == n", prop_fromChurchNat_toChurchNat)
-      , ("forall b. (fromChurchBool . toChurchBool) b == b", prop_fromChurchBool_toChurchBool)
+      [ ("forall n. (fromChurchNat . toChurchNat) n == n", prop_fromChurchNat_toChurchNat),
+        ("forall b. (fromChurchBool . toChurchBool) b == b", prop_fromChurchBool_toChurchBool)
       ]
 
 prop_fromChurchNat_toChurchNat :: Property

--- a/tests/Test.hs
+++ b/tests/Test.hs
@@ -3,9 +3,8 @@
 
 module Main where
 
-import Test.Tasty
-
 import PropertyTests
+import Test.Tasty
 import UnitTests
 
 main :: IO ()

--- a/tests/UnitTests.hs
+++ b/tests/UnitTests.hs
@@ -3,18 +3,17 @@
 
 module UnitTests (unitTests) where
 
+import Sly.Eval (hnf, whnf)
+import Sly.Syntax
+  ( Term (..),
+    fromChurchBool,
+    fromChurchNat,
+    toChurchBool,
+    toChurchNat,
+  )
 import Test.Hspec
 import Test.Tasty
 import Test.Tasty.Hspec
-
-import Sly.Eval (hnf, whnf)
-import Sly.Syntax (
-  Term (..),
-  fromChurchNat,
-  toChurchNat,
-  toChurchBool,
-  fromChurchBool,
- )
 
 unitTests :: IO TestTree
 unitTests = testSpec "Unit Tests" do


### PR DESCRIPTION
Format the codebase with Ormolu and add a job to the CI workflow which enforces that all Haskell source code is correctly formatted.