### PR TITLE
Shorten name of REUSE workflow

### DIFF
--- a/.github/workflows/reuse.yml
+++ b/.github/workflows/reuse.yml
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: 2025 Severen Redwood <sev@severen.dev>
 # SPDX-License-Identifier: CC0-1.0
 
-name: REUSE Compliance Check
+name: REUSE
 on:
   push:
     branches: [master]


### PR DESCRIPTION
The lengthiness of the name for the REUSE workflow bugs me, so shorten it from 'REUSE Compliance Check' to just 'REUSE'.